### PR TITLE
Sorted items by name length in /i-command

### DIFF
--- a/Rocket.Unturned/Commands/CommandI.cs
+++ b/Rocket.Unturned/Commands/CommandI.cs
@@ -63,10 +63,7 @@ namespace Rocket.Unturned.Commands
             {
                 List<ItemAsset> sortedAssets = new List<ItemAsset>(SDG.Unturned.Assets.find(EAssetType.ITEM).Cast<ItemAsset>());
                 sortedAssets.RemoveAll(value => value.Name == null);
-
-                sortedAssets.Sort((a1, a2) => {
-                    return a1.Name.Length.CompareTo(a2.Name.Length);
-                });
+                sortedAssets.Sort((a1, a2) => a1.Name.Length.CompareTo(a2.Name.Length));
 
                 ItemAsset asset = sortedAssets.Where(i => i.Name.ToLower().Contains(itemString.ToLower())).FirstOrDefault();
                 if (asset != null) id = asset.Id;

--- a/Rocket.Unturned/Commands/CommandI.cs
+++ b/Rocket.Unturned/Commands/CommandI.cs
@@ -62,10 +62,7 @@ namespace Rocket.Unturned.Commands
             if (!ushort.TryParse(itemString, out id))
             {
                 List<ItemAsset> sortedAssets = new List<ItemAsset>(SDG.Unturned.Assets.find(EAssetType.ITEM).Cast<ItemAsset>());
-                sortedAssets.RemoveAll(value => value.Name == null);
-                sortedAssets.Sort((a1, a2) => a1.Name.Length.CompareTo(a2.Name.Length));
-
-                ItemAsset asset = sortedAssets.Where(i => i.Name.ToLower().Contains(itemString.ToLower())).FirstOrDefault();
+                ItemAsset asset = sortedAssets.Where(asset => asset.Name != null).OrderBy(asset => asset.Name.Length).Where(i => i.Name.ToLower().Contains(itemString.ToLower())).FirstOrDefault();
                 if (asset != null) id = asset.Id;
                 if (String.IsNullOrEmpty(itemString.Trim()) || id == 0)
                 {

--- a/Rocket.Unturned/Commands/CommandI.cs
+++ b/Rocket.Unturned/Commands/CommandI.cs
@@ -62,13 +62,13 @@ namespace Rocket.Unturned.Commands
             if (!ushort.TryParse(itemString, out id)) 
             {
                 List<ItemAsset> sortedAssets = new List<ItemAsset>(SDG.Unturned.Assets.find(EAssetType.ITEM).Cast<ItemAsset>());
+                sortedAssets.RemoveAll(value => value.Name == null);
+
                 sortedAssets.Sort((a1, a2) => {
-                    if (a1.name != null && a2.name != null)
-                        return a1.name.Length.CompareTo(a2.name.Length);
-                    return 0;
+                    return a1.Name.Length.CompareTo(a2.Name.Length);
                 });
 
-                ItemAsset asset = sortedAssets.Where(i => i.Name != null && i.Name.ToLower().Contains(itemString.ToLower())).FirstOrDefault();
+                ItemAsset asset = sortedAssets.Where(i => i.Name.ToLower().Contains(itemString.ToLower())).FirstOrDefault();
                 if (asset != null) id = asset.Id;
                 if (String.IsNullOrEmpty(itemString.Trim()) || id == 0) 
                 {

--- a/Rocket.Unturned/Commands/CommandI.cs
+++ b/Rocket.Unturned/Commands/CommandI.cs
@@ -59,7 +59,7 @@ namespace Rocket.Unturned.Commands
 
             string itemString = command[0].ToString();
 
-            if (!ushort.TryParse(itemString, out id)) 
+            if (!ushort.TryParse(itemString, out id))
             {
                 List<ItemAsset> sortedAssets = new List<ItemAsset>(SDG.Unturned.Assets.find(EAssetType.ITEM).Cast<ItemAsset>());
                 sortedAssets.RemoveAll(value => value.Name == null);
@@ -67,7 +67,7 @@ namespace Rocket.Unturned.Commands
 
                 ItemAsset asset = sortedAssets.Where(i => i.Name.ToLower().Contains(itemString.ToLower())).FirstOrDefault();
                 if (asset != null) id = asset.Id;
-                if (String.IsNullOrEmpty(itemString.Trim()) || id == 0) 
+                if (String.IsNullOrEmpty(itemString.Trim()) || id == 0)
                 {
                     UnturnedChat.Say(player, U.Translate("command_generic_invalid_parameter"));
                     throw new WrongUsageOfCommandException(caller, this);

--- a/Rocket.Unturned/Commands/CommandI.cs
+++ b/Rocket.Unturned/Commands/CommandI.cs
@@ -6,6 +6,7 @@ using System.Collections.Generic;
 using Rocket.API;
 using Rocket.Unturned.Chat;
 using Rocket.Unturned.Items;
+using System.Linq;
 
 namespace Rocket.Unturned.Commands
 {
@@ -58,11 +59,18 @@ namespace Rocket.Unturned.Commands
 
             string itemString = command[0].ToString();
 
-            if (!ushort.TryParse(itemString, out id))
+            if (!ushort.TryParse(itemString, out id)) 
             {
-                ItemAsset asset = UnturnedItems.GetItemAssetByName(itemString.ToLower());
+                List<ItemAsset> sortedAssets = new List<ItemAsset>(SDG.Unturned.Assets.find(EAssetType.ITEM).Cast<ItemAsset>());
+                sortedAssets.Sort((a1, a2) => {
+                    if (a1.name != null && a2.name != null)
+                        return a1.name.Length.CompareTo(a2.name.Length);
+                    return 0;
+                });
+
+                ItemAsset asset = sortedAssets.Where(i => i.Name != null && i.Name.ToLower().Contains(itemString.ToLower())).FirstOrDefault();
                 if (asset != null) id = asset.Id;
-                if (String.IsNullOrEmpty(itemString.Trim()) || id == 0)
+                if (String.IsNullOrEmpty(itemString.Trim()) || id == 0) 
                 {
                     UnturnedChat.Say(player, U.Translate("command_generic_invalid_parameter"));
                     throw new WrongUsageOfCommandException(caller, this);


### PR DESCRIPTION
Items are sorted based on their name length to allow spawning in all items.

Currently, when you execute"/i rocket" it gives you a Rocket Launcher, and there is no way to get a rocket by typing its name.