### PR TITLE
Fixed Launch Locations?

### DIFF
--- a/Rocket.Unturned/Scripts/Linux/start.sh
+++ b/Rocket.Unturned/Scripts/Linux/start.sh
@@ -8,8 +8,8 @@ export MONO_IOMAP=all
 
 #CONFIG
 INSTANCE_NAME=$1
-STEAMCMD_HOME="$PWD/../../steamcmd"
-UNTURNED_HOME="$PWD/../"
+STEAMCMD_HOME="$PWD/../../../steamcmd"
+UNTURNED_HOME="$PWD/../../"
 
 #COLORS
 RED='\033[0;31m'

--- a/Rocket.Unturned/Scripts/Linux/update.sh
+++ b/Rocket.Unturned/Scripts/Linux/update.sh
@@ -6,8 +6,8 @@
 
 STEAM_USERNAME=$1
 STEAM_PASSWORD=$2
-STEAMCMD_HOME="$PWD/../../steamcmd"
-UNTURNED_HOME="$PWD/../"
+STEAMCMD_HOME="$PWD/../../../steamcmd"
+UNTURNED_HOME="$PWD/../../"
 
 mkdir -p $STEAMCMD_HOME
 mkdir -p $UNTURNED_HOME

--- a/Rocket.Unturned/Scripts/Windows/start.bat
+++ b/Rocket.Unturned/Scripts/Windows/start.bat
@@ -15,8 +15,8 @@ IF "%~1"=="-FIXED_CTRL_C" (
 
 SET INSTANCENAME=%1
 
-SET UNTURNEDHOME=%~dp0..\
-SET STEAMHOME=%~dp0..\..\Steam\
+SET UNTURNEDHOME=%~dp0..\..\
+SET STEAMHOME=%~dp0..\..\..\Steam\
 
 ECHO Steam directory: %STEAMHOME%
 ECHO Unturned directory: %UNTURNEDHOME%

--- a/Rocket.Unturned/Scripts/Windows/update.bat
+++ b/Rocket.Unturned/Scripts/Windows/update.bat
@@ -4,8 +4,8 @@ REM To quickstart, just create a new folder and place the contents of the Rocket
 REM Syntax: update.bat <unturned directory> <steam directory>
 REM Author: fr34kyn01535
 
-SET UNTURNEDHOME=%~dp0..\
-SET STEAMHOME=%~dp0..\..\Steam\
+SET UNTURNEDHOME=%~dp0..\..\
+SET STEAMHOME=%~dp0..\..\..\Steam\
 
 
 IF NOT EXIST %STEAMHOME% (


### PR DESCRIPTION
seeing windows/linux scripts are now in different spots though i'd update it. Should now be able to launch the server right from the default location of the scripts?

Does anything need to change in RocketLauncher.exe? (tbh i've never looked in RocketLauncher.exe so...)