### PR TITLE
Updated steamcmd source.

### DIFF
--- a/Rocket.Unturned/Scripts/Linux/update.sh
+++ b/Rocket.Unturned/Scripts/Linux/update.sh
@@ -14,7 +14,7 @@ mkdir -p $UNTURNED_HOME
 
 cd $STEAMCMD_HOME
 if [ ! -f "steamcmd.sh" ]; then
-	wget https://steamcdn-a.akamaihd.net/client/installer/steamcmd_linux.tar.gz
+	wget http://media.steampowered.com/client/steamcmd_linux.tar.gz
 	tar -xvzf steamcmd_linux.tar.gz
 	rm steamcmd_linux.tar.gz
 fi


### PR DESCRIPTION
SSL certificate for https://steamcdn-a.akamaihd.net/client/installer/steamcmd_linux.tar.gz can't be verified.
Exact message: ERROR: cannot verify steamcdn-a.akamaihd.net's certificate