### PR TITLE
Changes

### DIFF
--- a/Rocket.Unturned/Permissions/UnturnedPermissions.cs
+++ b/Rocket.Unturned/Permissions/UnturnedPermissions.cs
@@ -61,11 +61,10 @@ namespace Rocket.Unturned.Permissions
             try
             {
 
-                IOrderedEnumerable<RocketPermissionsGroup> playerGroups =
-                    R.Permissions.GetGroups(new RocketPlayer(r.m_SteamID.ToString()), true).OrderBy(x => x.Priority);
+                var playerGroups = R.Permissions.GetGroups(new RocketPlayer(r.m_SteamID.ToString()), true);
 
-                string prefix = playerGroups.FirstOrDefault(x => x.Prefix != null)?.Prefix ?? "";
-                string suffix = playerGroups.FirstOrDefault(x => x.Suffix != null)?.Suffix ?? "";
+                string prefix = playerGroups.FirstOrDefault(x => !string.IsNullOrEmpty(x.Prefix))?.Prefix ?? "";
+                string suffix = playerGroups.FirstOrDefault(x => !string.IsNullOrEmpty(x.Suffix))?.Suffix ?? "";
 
                 if (prefix != "" || suffix != "") 
                 {


### PR DESCRIPTION
Removed orderby(x => x.Priority) as it should be handled by the permissions provider directly.
Changed firstordefault from x.Prefix != null to !string.IsNullOrEmpty(x.Prefix) so that if the prefix is empty, a prefix/suffix is still applied if any exists elsewhere.