### PR TITLE
Fixed Rocket returning a fake UnturnedPlayer reference.

### DIFF
--- a/Rocket.Unturned/Player/UnturnedPlayer.cs
+++ b/Rocket.Unturned/Player/UnturnedPlayer.cs
@@ -155,7 +155,14 @@ namespace Rocket.Unturned.Player
             }
             else
             {
-                return new UnturnedPlayer(cSteamID);
+                UnturnedPlayer temp = new UnturnedPlayer(cSteamID);
+
+                if (temp.player == null)
+                {
+                    return null;
+                }
+
+                return temp;
             }
         }
 


### PR DESCRIPTION
If someone were to specify the `CSteamID` of an offline or non-existent player, `UnturnedPlayer.FromCSteamID` will return a non-null `UnturnedPlayer` reference.

The PR will instead cause it to return a `null` reference.

(yes I know I screwed the commit message up :D)