### PR TITLE
Fixed UnturnedPlayerManager.Ban()

### DIFF
--- a/Rocket.Unturned/Player/UnturnedPlayerManager.cs
+++ b/Rocket.Unturned/Player/UnturnedPlayerManager.cs
@@ -51,23 +51,23 @@ namespace Rocket.Unturned.Player
 
         public bool Ban(IUserInfo target, IUser bannedBy = null, string reason = null, TimeSpan? duration = null)
         {
-            //todo: this is wrong
-            var player = ((UnturnedUser)target).Player;
+            if (!(target is UnturnedUser user)) return;
+            var player = user.Player;
 
             PlayerBanEvent @event = new PlayerBanEvent(player.User, bannedBy, reason, duration, true);
             eventManager.Emit(host, @event);
             if (@event.IsCancelled)
                 return false;
 
-            if (target is IUser u && u.IsOnline)
+            var callerId = (bannedBy is UnturnedUser up) ? up.Player.CSteamID : CSteamID.Nil;
+
+            if (user.IsOnline)
             {
-                var uPlayer = ((UnturnedUser)target).Player;
-                Provider.ban(uPlayer.CSteamID, reason, (uint)(duration?.TotalSeconds ?? uint.MaxValue));
+                SteamBlacklist.ban(user.CSteamID, 0, callerId, reason, (uint)(duration?.TotalSeconds ?? uint.MaxValue));
                 return true;
             }
 
             var steamId = new CSteamID(ulong.Parse(target.Id));
-            var callerId = (bannedBy is UnturnedUser up) ? up.Player.CSteamID : CSteamID.Nil;
             SteamBlacklist.ban(steamId, 0, callerId, reason, (uint)(duration?.TotalSeconds ?? uint.MaxValue));
             return true;
         }

--- a/Rocket.Unturned/Player/UnturnedPlayerManager.cs
+++ b/Rocket.Unturned/Player/UnturnedPlayerManager.cs
@@ -51,7 +51,7 @@ namespace Rocket.Unturned.Player
 
         public bool Ban(IUserInfo target, IUser bannedBy = null, string reason = null, TimeSpan? duration = null)
         {
-            if (!(target is UnturnedUser user)) return;
+            if (!(target is UnturnedUser user)) return false;
             var player = user.Player;
 
             PlayerBanEvent @event = new PlayerBanEvent(player.User, bannedBy, reason, duration, true);
@@ -63,7 +63,7 @@ namespace Rocket.Unturned.Player
 
             if (user.IsOnline)
             {
-                SteamBlacklist.ban(user.CSteamID, 0, callerId, reason, (uint)(duration?.TotalSeconds ?? uint.MaxValue));
+                SteamBlacklist.ban(player.CSteamID, 0, callerId, reason, (uint)(duration?.TotalSeconds ?? uint.MaxValue));
                 return true;
             }
 


### PR DESCRIPTION
It used `Provider.ban()`, which doesn't actually ban the player, only disconnects them from the server as if they were banned (Changed to `SteamBlacklist.ban()` which was correctly used for when the player was offline, but not when online).
Also changed `var player = ((UnturnedUser)target).Player;` for `if (!(target is UnturnedUser user)) return false;`.
Removed as well the second time it casted Target to UnturnedUser when the cast already had happened.